### PR TITLE
Ensure BadUpdate Tools asset is fetched

### DIFF
--- a/BadBuilder/Helpers/DownloadHelper.cs
+++ b/BadBuilder/Helpers/DownloadHelper.cs
@@ -9,32 +9,55 @@ namespace BadBuilder.Helpers
     {
         internal static async Task GetGitHubAssets(List<DownloadItem> items)
         {
-            GitHubClient gitClient = new(new ProductHeaderValue("BadBuilder-Downloader"));
-            List<string> repos =
-            [
-                "grimdoomer/Xbox360BadUpdate",
-                "Byrom90/XeUnshackle",
-                "FreeMyXe/FreeMyXe"
-            ];
-
-            foreach (var repo in repos)
+            try
             {
-                string[] splitRepo = repo.Split('/');
-                var latestRelease = await gitClient.Repository.Release.GetLatest(splitRepo[0], splitRepo[1]);
+                GitHubClient gitClient = new(new ProductHeaderValue("BadBuilder-Downloader"));
+                List<string> repos =
+                [
+                    "Byrom90/XeUnshackle",
+                    "FreeMyXe/FreeMyXe"
+                ];
 
-                foreach (var asset in latestRelease.Assets)
+                foreach (var repo in repos)
                 {
-                    string friendlyName = asset.Name switch
-                    {
-                        var name when name.Contains("Free", StringComparison.OrdinalIgnoreCase) => "FreeMyXe",
-                        var name when name.Contains("Tools", StringComparison.OrdinalIgnoreCase) => "BadUpdate Tools",
-                        var name when name.Contains("BadUpdate", StringComparison.OrdinalIgnoreCase) => "BadUpdate",
-                        var name when name.Contains("XeUnshackle", StringComparison.OrdinalIgnoreCase) => "XeUnshackle",
-                        _ => asset.Name.Substring(0, asset.Name.Length - 4)
-                    };
+                    string[] splitRepo = repo.Split('/');
+                    var latestRelease = await gitClient.Repository.Release.GetLatest(splitRepo[0], splitRepo[1]);
 
-                    items.Add(new(friendlyName, asset.BrowserDownloadUrl));
+                    foreach (var asset in latestRelease.Assets)
+                    {
+                        string friendlyName = asset.Name switch
+                        {
+                            var name when name.Contains("Free", StringComparison.OrdinalIgnoreCase) => "FreeMyXe",
+                            var name when name.Contains("XeUnshackle", StringComparison.OrdinalIgnoreCase) => "XeUnshackle",
+                            _ => asset.Name.Substring(0, asset.Name.Length - 4)
+                        };
+
+                        items.Add(new(friendlyName, asset.BrowserDownloadUrl));
+                    }
                 }
+
+                string[] badUpdateRepo = "grimdoomer/Xbox360BadUpdate".Split('/');
+                var releases = await gitClient.Repository.Release.GetAll(badUpdateRepo[0], badUpdateRepo[1]);
+
+                foreach (var release in releases)
+                {
+                    var toolsAsset = release.Assets.FirstOrDefault(asset =>
+                        asset.Name.Contains("Tools", StringComparison.OrdinalIgnoreCase));
+                    var badUpdateAsset = release.Assets.FirstOrDefault(asset =>
+                        asset.Name.Contains("BadUpdate", StringComparison.OrdinalIgnoreCase) &&
+                        !asset.Name.Contains("Tools", StringComparison.OrdinalIgnoreCase));
+
+                    if (toolsAsset is null || badUpdateAsset is null)
+                        continue;
+
+                    items.Add(new("BadUpdate Tools", toolsAsset.BrowserDownloadUrl));
+                    items.Add(new("BadUpdate", badUpdateAsset.BrowserDownloadUrl));
+                    break;
+                }
+            }
+            catch (Exception ex)
+            {
+                AnsiConsole.MarkupLine($"[red]Error fetching GitHub release assets: {ex}[/]");
             }
         }
 


### PR DESCRIPTION
The BadUpdate repo `grimdoomer/Xbox360BadUpdate` created a new release that does not contain `Tools.zip` which is required for `BadBuilder.Helpers.PatchHelper.PatchXexAsync` after it is extracted, resulting in a crash:

```
Unhandled exception. System.AggregateException: One or more errors occurred. (Cannot start process because a file name has not been provided.)
 ---> System.InvalidOperationException: Cannot start process because a file name has not been provided.
   at System.Diagnostics.Process.Start()
   at BadBuilder.Helpers.PatchHelper.PatchXexAsync(String xexPath, String xexToolPath)
   at BadBuilder.Program.<>cDisplayClass19_2.<<Main>b3>d.MoveNext()
--- End of stack trace from previous location ---
   at BadBuilder.Utilities.ActionQueue.ExecuteActionsAsync()
   --- End of inner exception stack trace ---
   at System.Threading.Tasks.Task.ThrowIfExceptional(Boolean includeTaskCanceledExceptions)
   at System.Threading.Tasks.Task.Wait(Int32 millisecondsTimeout, CancellationToken cancellationToken)
   at System.Threading.Tasks.Task.Wait()
   at BadBuilder.Program.Main(String[] args)
```

The following changes ensures that the assets fetched from a  `grimdoomer/Xbox360BadUpdate` release contains both `Xbox360BadUpdate-Retail-USB-*.zip` and `Tools.zip`.