### PR TITLE
Add macOS disk formatting support

### DIFF
--- a/BadBuilder/Application/BuilderApp.cs
+++ b/BadBuilder/Application/BuilderApp.cs
@@ -78,10 +78,13 @@ internal static partial class BuilderApp
                     throw new InvalidOperationException("The selected default homebrew has no valid entry point.");
             }
 
-            if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            bool canFormat = RuntimeInformation.IsOSPlatform(OSPlatform.Windows) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+            if (!canFormat)
             {
-                Controls.WriteWarning("Drive formatting is currently only supported on Windows. Please format the drive manually to FAT32 before proceeding.");
+                Controls.WriteWarning("Drive formatting is currently only supported on Windows and macOS. Please format the drive manually to FAT32 before proceeding.");
                 Controls.Pause("Press enter after you have formatted the drive.");
+                Config.MountPoint = Controls.PromptText("Enter the mount point of your formatted drive (e.g. /media/usb)");
             }
             else
             {

--- a/BadBuilder/Services/Disks/DiskService.Windows.cs
+++ b/BadBuilder/Services/Disks/DiskService.Windows.cs
@@ -42,7 +42,7 @@ internal static partial class DiskService
     }
 
     [SupportedOSPlatform("windows")]
-    private static RawDiskStream OpenRawDiskForWrite(DiskInfo disk)
+    private static RawDiskStream OpenRawDiskForWriteWindows(DiskInfo disk)
     {
         int diskIndex                = int.Parse(disk.ID);
         List<VolumeLock> volumeLocks = LockAndDismountVolumes(diskIndex);

--- a/BadBuilder/Services/Disks/DiskService.cs
+++ b/BadBuilder/Services/Disks/DiskService.cs
@@ -8,22 +8,27 @@ namespace BadBuilder.Services.Disks;
 
 internal static partial class DiskService
 {
-    internal static List<DiskInfo> EnumerateDisks() => InvokePlatformAction(EnumerateDisksWindows, null, null); // TODO: Implement for macOS and Linux
+    internal static List<DiskInfo> EnumerateDisks() => InvokePlatformAction(EnumerateDisksWindows, EnumerateDisksMacos, null);
 
     internal static string FormatFAT32(DiskInfo disk)
     {
         ArgumentNullException.ThrowIfNull(disk);
 
-        using RawDiskStream stream = OpenRawDiskForWrite(disk);
-        using Disk virtualDisk     = new(stream, Ownership.None);
+        {
+            using RawDiskStream stream = OpenRawDiskForWrite(disk);
+            using Disk virtualDisk     = new(stream, Ownership.None);
 
-        BiosPartitionTable.Initialize(virtualDisk, WellKnownPartitionType.WindowsFat);
+            BiosPartitionTable.Initialize(virtualDisk, WellKnownPartitionType.WindowsFat);
 
-        using FatFileSystem fs = FatFileSystem.FormatPartition(virtualDisk, 0, "BADUPDATE  ");
-        stream.Flush();
+            using FatFileSystem fs = FatFileSystem.FormatPartition(virtualDisk, 0, "BADUPDATE  ");
+            stream.Flush();
+        }
 
-        return InvokePlatformAction(ReassignWindows, null, null, disk); // TODO: Implement for macOS and Linux
+        return InvokePlatformAction(ReassignWindows, ReassignMacos, null, disk);
     }
+
+    private static RawDiskStream OpenRawDiskForWrite(DiskInfo disk)
+        => InvokePlatformAction(OpenRawDiskForWriteWindows, OpenRawDiskForWriteMacos, null, disk);
 
 
     private static string RunProcess(string fileName, string arguments)

--- a/BadBuilder/Services/Disks/DiskService.macOS.cs
+++ b/BadBuilder/Services/Disks/DiskService.macOS.cs
@@ -1,0 +1,156 @@
+using System.Runtime.Versioning;
+using System.Xml.Linq;
+
+namespace BadBuilder.Services.Disks;
+
+internal static partial class DiskService
+{
+    [SupportedOSPlatform("macos")]
+    private static List<DiskInfo> EnumerateDisksMacos()
+    {
+        XElement root = ParsePlist(RunProcess("diskutil", "list -plist"));
+
+        List<DiskInfo> disks = [];
+
+        foreach (string deviceId in GetArrayStrings(root, "WholeDisks"))
+        {
+            XElement info = ParsePlist(RunProcess("diskutil", $"info -plist /dev/{deviceId}"));
+
+            if (GetBool(info, "Internal"))   continue;
+            if (GetBool(info, "SystemImage")) continue;
+
+            if (string.Equals(GetString(info, "VirtualOrPhysical"), "Virtual", StringComparison.OrdinalIgnoreCase))
+                continue;
+
+            long size = GetLong(info, "Size") ?? 0;
+            if (size <= 0) continue;
+
+            string mediaName = GetString(info, "MediaName") ?? "";
+            if (string.IsNullOrWhiteSpace(mediaName)) mediaName = $"Disk {deviceId}";
+
+            string protocol = GetString(info, "BusProtocol") ?? "";
+            bool removable  = GetBool(info, "Removable") ||
+                              protocol.Equals("USB", StringComparison.OrdinalIgnoreCase);
+
+            disks.Add(new DiskInfo(
+                ID: deviceId,
+                Name: mediaName,
+                Size: size,
+                Type: removable ? DriveType.Removable : DriveType.Fixed,
+                DevicePath: $"/dev/{deviceId}"
+            ));
+        }
+
+        return disks;
+    }
+
+    [SupportedOSPlatform("macos")]
+    private static RawDiskStream OpenRawDiskForWriteMacos(DiskInfo disk)
+    {
+        string devicePath = $"/dev/{disk.ID}";
+
+        RunProcess("diskutil", $"unmountDisk force {devicePath}");
+
+        FileStream fileStream = new(
+            $"/dev/r{disk.ID}",
+            new FileStreamOptions
+            {
+                Mode       = FileMode.Open,
+                Access     = FileAccess.ReadWrite,
+                BufferSize = 512,
+            }
+        );
+
+        return new RawDiskStream(fileStream, disk.Size);
+    }
+
+    [SupportedOSPlatform("macos")]
+    private static string ReassignMacos(DiskInfo disk)
+    {
+        string devicePath = $"/dev/{disk.ID}";
+
+        for (int attempt = 0; attempt < 30; attempt++)
+        {
+            Thread.Sleep(500);
+
+            string listOutput = RunProcess("diskutil", $"list -plist {devicePath}");
+
+            XElement list  = ParsePlist(listOutput);
+            string? mount  = GetArrayDicts(list, "AllDisksAndPartitions")
+                .SelectMany(entry => GetArrayDicts(entry, "Partitions"))
+                .Select(partition => GetString(partition, "MountPoint"))
+                .FirstOrDefault(mountPoint => !string.IsNullOrWhiteSpace(mountPoint));
+
+            if (mount is not null) return mount;
+
+            if (attempt % 2 == 0)
+                RunProcess("diskutil", $"mountDisk {devicePath}");
+        }
+
+        throw new IOException($"Formatted {devicePath} but no volume was mounted. Mount the drive manually and copy the files.");
+    }
+
+
+    private static XElement ParsePlist(string plist)
+    {
+        int doctypeStart = plist.IndexOf("<!DOCTYPE", StringComparison.Ordinal);
+        if (doctypeStart >= 0)
+        {
+            int doctypeEnd = plist.IndexOf('>', doctypeStart);
+            if (doctypeEnd >= 0)
+                plist = plist.Remove(doctypeStart, doctypeEnd - doctypeStart + 1);
+        }
+
+        return XDocument.Parse(plist).Root?.Element("dict")
+            ?? throw new InvalidOperationException("Unexpected plist format from diskutil.");
+    }
+
+    private static XElement? SiblingAfterKey(XElement dict, string key)
+    {
+        foreach (XElement keyElement in dict.Elements("key"))
+        {
+            if (keyElement.Value != key) continue;
+            return keyElement.ElementsAfterSelf().FirstOrDefault();
+        }
+
+        return null;
+    }
+
+    private static string? GetString(XElement dict, string key)
+    {
+        XElement? sibling = SiblingAfterKey(dict, key);
+        return sibling?.Name == "string" ? sibling.Value : null;
+    }
+
+    private static bool GetBool(XElement dict, string key)
+    {
+        XElement? sibling = SiblingAfterKey(dict, key);
+        return sibling?.Name == "true";
+    }
+
+    private static long? GetLong(XElement dict, string key)
+    {
+        XElement? sibling = SiblingAfterKey(dict, key);
+        return sibling?.Name == "integer" && long.TryParse(sibling.Value, out long value) ? value : null;
+    }
+
+    private static IEnumerable<string> GetArrayStrings(XElement dict, string key)
+    {
+        XElement? sibling = SiblingAfterKey(dict, key);
+        if (sibling?.Name != "array") yield break;
+
+        foreach (XElement child in sibling.Elements())
+            if (child.Name == "string")
+                yield return child.Value;
+    }
+
+    private static IEnumerable<XElement> GetArrayDicts(XElement dict, string key)
+    {
+        XElement? sibling = SiblingAfterKey(dict, key);
+        if (sibling?.Name != "array") yield break;
+
+        foreach (XElement child in sibling.Elements())
+            if (child.Name == "dict")
+                yield return child;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 BadBuilder is a tool for creating BadUpdate/ABadAvatar USB drives for the Xbox 360. It automates the process of formatting the USB drive, downloading required files, extracting them, adding homebrew, and downloading dashboard updates if needed.
 
 ## Features
-### USB Formatting (Windows Only)
+### USB Formatting (Windows & macOS)
 - Uses a custom FAT32 formatter that supports large USB drives (≥32GB).
 - Ensures compatibility with the Xbox 360.
 - Much more stable than the formatter in BadBuilder v1.
 
 > [!NOTE]  
-> Currently, the formatting feature is **Windows-only**. If you compile BadBuilder for another OS, it'll prompt you to manually format your target disk.
+> The formatting feature is supported on **Windows and macOS**. On other operating systems (e.g. Linux), BadBuilder will prompt you to manually format your target disk.
 
 ### Automatic File Downloading
 - Detects and downloads the latest required files automatically.


### PR DESCRIPTION
Adds full macOS support for BadBuilder's USB drive handling:

- **New `DiskService.macOS.cs`**: drive enumeration via `diskutil` (internal/virtual disks filtered), raw-device formatting through `/dev/rdiskX`, and automatic remount with mount-point detection.
- **`DiskService.cs`**: wires the macOS implementations into the platform dispatch and disposes the raw stream before remounting (previously the still-open handle silently prevented mounting).
- **`BuilderApp.cs`**: macOS now uses the automatic format flow; other platforms get a manual mount-point prompt.
- **README**: updated the formatting note to Windows & macOS.

Tested on macOS 14 with a 16 GB USB stick: enumeration, FAT32 format, and remount to `/Volumes/BADUPDATE` all verified.